### PR TITLE
Add instructions for adding ActiveModelSerializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ class Game < ActiveRecord::Base
 end
 ```
 
+Add ActiveModelSerializers to your project by adding this line to your application's Gemfile:
+
+```
+gem "active_model_serializers", "0.8.3"
+```
+And then execute:
+
+```
+$ bundle
+```
+
 Generate a serializer:
 
 ```


### PR DESCRIPTION
The ActiveModelSerializers gem must be added before a serializer can be generated. 
This adds instructions to the README. 

Question--- is there a particular version of AMS that should be used? 
